### PR TITLE
Update inferencems.py

### DIFF
--- a/vits/inferencems.py
+++ b/vits/inferencems.py
@@ -36,6 +36,8 @@ def langdetector(text):
             return f'[EN]{text}[EN]'
         elif lang == 'zh-cn':
             return f'[ZH]{text}[ZH]'
+        else:
+            return text
     except Exception as e:
         return text
 


### PR DESCRIPTION
Somehow, the langdetect classified word "apple" as French, returning 'FR'. As no exception occurs from those if statements, there was no way to handle such case, resulting in none type object text.